### PR TITLE
Fix: Correct button text visibility and replace remaining text

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -11,7 +11,7 @@ export default function AboutPage() {
       <nav className="fixed top-0 left-0 right-0 z-50 bg-black/95 backdrop-blur-md px-4 py-4">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <Link href="/" className="text-xl font-poppins font-semibold text-white">
-            Hello Support<span className="text-red-500">!</span>
+            Digital Genius<span className="text-red-500">!</span>
           </Link>
           <Link href="/">
             <Button variant="outline" className="border-white text-white hover:bg-white hover:text-black">
@@ -30,7 +30,7 @@ export default function AboutPage() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
           >
-            About <span className="text-blue-400">Hello Support</span>
+            About <span className="text-blue-400">Digital Genius</span>
           </motion.h1>
 
           <motion.p
@@ -57,7 +57,7 @@ export default function AboutPage() {
               <h2 className="text-4xl font-bold mb-6 font-poppins">Our Story</h2>
               <p className="text-lg text-gray-300 mb-6 leading-relaxed font-poppins">
                 Founded with a vision to revolutionize how businesses approach marketing and operations,
-                Hello Support has grown from a small team of passionate professionals to a full-service
+                Digital Genius has grown from a small team of passionate professionals to a full-service
                 digital marketing agency that empowers businesses to achieve scalable growth.
               </p>
               <p className="text-lg text-gray-300 leading-relaxed font-poppins">

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -41,10 +41,10 @@ export default function ContactPage() {
       <nav className="fixed top-0 left-0 right-0 z-50 bg-black/95 backdrop-blur-md px-4 py-4">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <Link href="/" className="text-xl font-poppins font-semibold text-white">
-            Hello Support<span className="text-red-500">!</span>
+            Digital Genius<span className="text-red-500">!</span>
           </Link>
           <Link href="/">
-            <Button variant="outline" className="border-white text-white hover:bg-white hover:text-black">
+            <Button variant="outline" className="border-white text-black hover:bg-gray-200 hover:text-black">
               ← Back to Home
             </Button>
           </Link>
@@ -209,7 +209,7 @@ export default function ContactPage() {
                   </div>
                   <div>
                     <h3 className="text-xl font-bold font-poppins">Email</h3>
-                    <p className="text-gray-300 font-poppins">info@hellosupport.io</p>
+                    <p className="text-gray-300 font-poppins">info@digitalgenius.io</p>
                   </div>
                 </div>
 
@@ -318,7 +318,7 @@ export default function ContactPage() {
                 answer: "Yes! We work with startups, small businesses, and established enterprises. Our strategies are scalable and customized to your specific business stage and goals."
               },
               {
-                question: "What makes Hello Support different from other agencies?",
+                question: "What makes Digital Genius different from other agencies?",
                 answer: "We focus on partnership over transactions. We educate and empower your team while delivering results, ensuring you have the knowledge and tools for long-term success."
               },
               {

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -80,10 +80,10 @@ export default function ServicesPage() {
       <nav className="fixed top-0 left-0 right-0 z-50 bg-black/95 backdrop-blur-md px-4 py-4">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <Link href="/" className="text-xl font-poppins font-semibold text-white">
-            Hello Support<span className="text-red-500">!</span>
+            Digital Genius<span className="text-red-500">!</span>
           </Link>
           <Link href="/">
-            <Button variant="outline" className="border-white text-white hover:bg-white hover:text-black">
+            <Button variant="outline" className="border-white text-black hover:bg-gray-200 hover:text-black">
               ← Back to Home
             </Button>
           </Link>
@@ -159,7 +159,7 @@ export default function ServicesPage() {
                         </Button>
                       </Link>
                       <Link href="/contact">
-                        <Button variant="outline" className="border-gray-600 text-gray-300 hover:bg-gray-700 font-poppins">
+                        <Button variant="outline" className="border-gray-600 text-gray-700 hover:bg-gray-800 hover:text-gray-100 font-poppins">
                           Get Quote
                         </Button>
                       </Link>
@@ -242,7 +242,7 @@ export default function ServicesPage() {
               </Button>
             </Link>
             <Link href="/about">
-              <Button size="lg" variant="outline" className="border-white text-white hover:bg-white hover:text-black font-poppins px-8 py-3">
+              <Button size="lg" variant="outline" className="border-white text-black hover:bg-gray-200 hover:text-black font-poppins px-8 py-3">
                 Learn About Us
               </Button>
             </Link>

--- a/src/app/services/seo/page.tsx
+++ b/src/app/services/seo/page.tsx
@@ -12,7 +12,7 @@ export default function SEOPage() {
       <nav className="fixed top-0 left-0 right-0 z-50 bg-black/95 backdrop-blur-md px-4 py-4">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <Link href="/" className="text-xl font-poppins font-semibold text-white">
-            Hello Support<span className="text-red-500">!</span>
+            Digital Genius<span className="text-red-500">!</span>
           </Link>
           <div className="flex items-center space-x-4">
             <Link href="/services">


### PR DESCRIPTION
This commit addresses your feedback regarding:
1.  Button text visibility:
    - Text on certain outline buttons on the Services and Contact pages was not visible by default. This occurred because these pages use a dark 'main' background without activating global dark mode, causing the outline buttons' default white background to clash with their white text.
    - I fixed this by changing text color to black or dark gray on the affected buttons in their default state (e.g., "Back to Home", "Get Quote", "Learn About Us"). Hover states were also adjusted for consistency.

2.  Remaining text replacements:
    - I ensured all instances of "Hello Support" (and variants) were changed to "Digital Genius" (and variants) on pages like About, Contact, Services, and SEO service page, including in navigation elements and content text.

All changes from the previous commit (feat/rename-hello-support-to-digital-genius) are included. This commit finalizes the requested updates.